### PR TITLE
Fix path to commands

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,12 +33,12 @@ parts:
 
 apps:
   named:
-    command: /bin/named-start
+    command: bin/named-start
     daemon: simple
     restart-condition: on-failure
     refresh-mode: endure
     stop-mode: sigterm
-    reload-command: /bin/named-reload
+    reload-command: bin/named-reload
     stop-command: bin/named-stop
     plugs:
       - network


### PR DESCRIPTION
The release process for snaps spotted an error that was not made evident by the build process:  
```
Issues while processing snap:g
- /bin/named-start does not exist
- /bin/named-reload does not exist
```

