### PR TITLE
Fix the CI and the install hook

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,11 +25,21 @@ jobs:
           cd api
           DJANGO_SECRET_KEY="testkey" python3 manage.py test
 
+  build-snap:
+    name: Build snap
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v16
+
   snap-tests:
+    name: Test the resulting snap
     runs-on: ubuntu-latest
+    needs:
+      - build-snap
     steps:
-      - name: Build snap
-        uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v16
+      - name: Download snap package(s)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
+          merge-multiple: true
 
       - name: Install snap
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,6 +49,9 @@ jobs:
         run: |
           sudo snap services charmed-bind | awk 'NR > 1 && $3 != "active" {exit 1}'
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Check admin interface
         run: |
           curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,5 +51,5 @@ jobs:
 
       - name: Check admin interface
         run: |
-          curl -f --retry 5 --retry-delay 10 http://localhost:8080/admin/login
           curl -f --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
+          curl -f --retry 5 --retry-delay 10 http://localhost:8080/admin/login/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,5 +51,5 @@ jobs:
 
       - name: Check admin interface
         run: |
-          curl -f --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
-          curl -f --retry 5 --retry-delay 10 http://localhost:8080/admin/login/
+          curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
+          curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/admin/login/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,5 +51,5 @@ jobs:
 
       - name: Check admin interface
         run: |
-          curl -f http://localhost:8080/admin
-          curl -f http://localhost:8080/static/admin/css/base.css
+          curl -f --retry 5 --retry-delay 10 http://localhost:8080/admin
+          curl -f --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,5 +51,5 @@ jobs:
 
       - name: Check admin interface
         run: |
-          curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
-          curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/admin/login/
+          curl --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
+          curl --retry 5 --retry-delay 10 http://localhost:8080/admin/login/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Download snap package(s)
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
+          pattern: ${{ needs.build-snap.outputs.artifact-prefix }}-*
           merge-multiple: true
 
       - name: Install snap

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,9 +49,6 @@ jobs:
         run: |
           sudo snap services charmed-bind | awk 'NR > 1 && $3 != "active" {exit 1}'
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Check admin interface
         run: |
           curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,5 +51,5 @@ jobs:
 
       - name: Check admin interface
         run: |
-          curl -f --retry 5 --retry-delay 10 http://localhost:8080/admin
+          curl -f --retry 5 --retry-delay 10 http://localhost:8080/admin/login
           curl -f --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,11 +43,11 @@ jobs:
 
       - name: Install snap
         run: |
-          snap install --dangerous charmed-bind_*.snap
+          sudo snap install --dangerous charmed-bind_*.snap
 
       - name: Verify that all services are active
         run: |
-          snap services charmed-bind | awk 'NR > 1 && $3 != "active" {exit 1}'
+          sudo snap services charmed-bind | awk 'NR > 1 && $3 != "active" {exit 1}'
 
       - name: Check admin interface
         run: |

--- a/api/dns/settings.py
+++ b/api/dns/settings.py
@@ -124,8 +124,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
 STATIC_URL = 'static/'
-static_root_path = os.getenv("SNAP_DATA") or BASE_DIR
-STATIC_ROOT = os.path.join(static_root_path, '/api/static/')
+STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field

--- a/api/dns/settings.py
+++ b/api/dns/settings.py
@@ -124,7 +124,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
 STATIC_URL = 'static/'
-STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
+STATIC_ROOT = Path(BASE_DIR, 'static/')
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -27,7 +27,6 @@ cat "$SNAP_DATA/etc/bind/rndc.conf" | awk '/^# (Start|End|Use)/ {next} /^#/ {sub
 
 # Copy nginx configuration
 cp -r --preserve=mode "$SNAP/nginx" "$SNAP_DATA/nginx"
-cp -r --preserve=mode "$SNAP/api" "$SNAP_DATA/api"
 
 # Create some directories for nginx
 mkdir -p $SNAP_DATA/nginx/tmp/body
@@ -41,6 +40,15 @@ sed -i \
   -e "s|<SNAP_DATA>|${SNAP_DATA}|g" \
   -e "s|<SNAP_COMMON>|${SNAP_COMMON}|g" \
   "$SNAP_DATA/nginx/nginx.conf"
+
+# Create the static directory for django
+cp -r "$SNAP/api" "$SNAP_DATA/"
+chmod -R 755 $SNAP_DATA/api
+
+# Prepare the django app
+cd $SNAP_DATA/api
+DJANGO_SECRET_KEY="testkey" python3 manage.py collectstatic --noinput
+DJANGO_SECRET_KEY="testkey" python manage.py migrate --noinput
 
 # Change ownership of some snap directories to allow snap_daemon to read/write
 # https://snapcraft.io/docs/system-usernames


### PR DESCRIPTION
The previous PR left the CI workflow in a broken state.  
This fixes it by splitting the snap test into a build job and a test job.

I also had to fix the install hook to correctly aggregate static assets and create the database for the django app.

I took a lot of time to understand that changing ownership of some snap directories to allow snap_daemon to read/write should be done at the end of the install hook to not interfere with the collecstatic operation.