### PR TITLE
Restrict django allowed hosts

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,6 +52,4 @@ jobs:
       - name: Check admin interface
         run: |
           sleep 180 # wait a bit for things to start
-          sudo snap set charmed-bind django-allowed-hosts='["localhost"]'
-          curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
-          curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/admin/login/
+          curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/admin/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,6 +49,9 @@ jobs:
         run: |
           sudo snap services charmed-bind | awk 'NR > 1 && $3 != "active" {exit 1}'
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Check admin interface
         run: |
           sleep 60 # wait a bit for things to start

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,6 +44,7 @@ jobs:
       - name: Install snap
         run: |
           sudo snap install --dangerous charmed-bind_*.snap
+          sleep 10 # wait a bit for things to start
 
       - name: Verify that all services are active
         run: |
@@ -51,6 +52,5 @@ jobs:
 
       - name: Check admin interface
         run: |
-          sleep 180 # wait a bit for things to start
-          curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
-          curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/admin/login/
+          curl --fail-with-body --retry-all-errors --retry 10 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
+          curl --fail-with-body --retry-all-errors --retry 10 --retry-delay 10 http://localhost:8080/admin/login/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Check admin interface
         run: |
+          sudo snap set django-allowed-hosts="['*']"
           sleep 60 # wait a bit for things to start
           curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
           curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/admin/login/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Check admin interface
         run: |
-          sudo snap set django-allowed-hosts="['*']"
+          sudo snap set charmed-bind django-allowed-hosts="['localhost']"
           sleep 60 # wait a bit for things to start
           curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
           curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/admin/login/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,7 +51,9 @@ jobs:
 
       - name: Check admin interface
         run: |
-          sudo snap set charmed-bind django-allowed-hosts="['localhost']"
           sleep 60 # wait a bit for things to start
+          sudo snap set charmed-bind django-allowed-hosts="['localhost', '*']"
+          sudo snap restart charmed-bind
+          sleep 10 # wait a bit for things to restart
           curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
           curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/admin/login/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,14 +49,9 @@ jobs:
         run: |
           sudo snap services charmed-bind | awk 'NR > 1 && $3 != "active" {exit 1}'
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Check admin interface
         run: |
           sleep 60 # wait a bit for things to start
           sudo snap set charmed-bind django-allowed-hosts='["localhost"]'
-          sudo snap restart charmed-bind
-          sleep 10 # wait a bit for things to restart
           curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
           curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/admin/login/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,12 +49,9 @@ jobs:
         run: |
           sudo snap services charmed-bind | awk 'NR > 1 && $3 != "active" {exit 1}'
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Check admin interface
         run: |
-          sleep 60 # wait a bit for things to start
+          sleep 180 # wait a bit for things to start
           sudo snap set charmed-bind django-allowed-hosts='["localhost"]'
           curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
           curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/admin/login/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,4 +52,5 @@ jobs:
       - name: Check admin interface
         run: |
           sleep 180 # wait a bit for things to start
-          curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/admin/
+          curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
+          curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/admin/login/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,10 +49,13 @@ jobs:
         run: |
           sudo snap services charmed-bind | awk 'NR > 1 && $3 != "active" {exit 1}'
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Check admin interface
         run: |
           sleep 60 # wait a bit for things to start
-          sudo snap set charmed-bind django-allowed-hosts="['localhost', '*']"
+          sudo snap set charmed-bind django-allowed-hosts='["localhost"]'
           sudo snap restart charmed-bind
           sleep 10 # wait a bit for things to restart
           curl --fail-with-body --retry 5 --retry-delay 10 http://localhost:8080/static/admin/css/base.css

--- a/api/dns/settings.py
+++ b/api/dns/settings.py
@@ -30,8 +30,7 @@ try:
     env_allowed_hosts = json.loads(os.getenv("DJANGO_ALLOWED_HOSTS", "[]"))
 except json.decoder.JSONDecodeError:
     env_allowed_hosts = []
-ALLOWED_HOSTS = env_allowed_hosts + ["localhost", "127.0.0.1", "0.0.0.0"]
-
+ALLOWED_HOSTS = env_allowed_hosts
 
 # Application definition
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -56,5 +56,5 @@ chown -R 584788:root $SNAP_DATA/nginx
 chown -R 584788:root $SNAP_DATA/api
 
 # set default configuration values
-snapctl set django-debug="false"
-snapctl set django-allowed-hosts="['localhost', '127.0.0.1', '0.0.0.0']"
+snapctl set django-debug='false'
+snapctl set django-allowed-hosts='["localhost", "127.0.0.1", "0.0.0.0"]'


### PR DESCRIPTION
This is done to have full control over allowed hosts and deny them completely if need be.