### PR TITLE
Rework snap files to handle refreshes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,9 @@ jobs:
           pattern: ${{ needs.build-snap.outputs.artifact-prefix }}-*
           merge-multiple: true
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Install snap
         run: |
           sudo snap install --dangerous charmed-bind_*.snap
@@ -53,4 +56,4 @@ jobs:
       - name: Check admin interface
         run: |
           curl --fail-with-body --retry-all-errors --retry 10 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
-          curl --fail-with-body --retry-all-errors --retry 10 --retry-delay 10 http://localhost:8080/admin/login/
+          curl --fail-with-body --retry-all-errors --retry 11 --retry-delay 10 http://localhost:8080/admin/login/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,12 +41,6 @@ jobs:
           pattern: ${{ needs.build-snap.outputs.artifact-prefix }}-*
           merge-multiple: true
 
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Install snap
         run: |
           sudo snap install --dangerous charmed-bind_*.snap

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,9 @@ jobs:
           pattern: ${{ needs.build-snap.outputs.artifact-prefix }}-*
           merge-multiple: true
 
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,4 +53,4 @@ jobs:
       - name: Check admin interface
         run: |
           curl --fail-with-body --retry-all-errors --retry 10 --retry-delay 10 http://localhost:8080/static/admin/css/base.css
-          curl --fail-with-body --retry-all-errors --retry 11 --retry-delay 10 http://localhost:8080/admin/login/
+          curl --fail-with-body --retry-all-errors --retry 10 --retry-delay 10 http://localhost:8080/admin/login/

--- a/api/dns/settings.py
+++ b/api/dns/settings.py
@@ -81,9 +81,9 @@ WSGI_APPLICATION = 'dns.wsgi.application'
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.getenv("DJANGO_DATABASE_PATH", BASE_DIR / 'db.sqlite3'),
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.getenv("DJANGO_DATABASE_PATH", BASE_DIR / "db.sqlite3"),
     }
 }
 

--- a/api/dns/settings.py
+++ b/api/dns/settings.py
@@ -83,7 +83,7 @@ WSGI_APPLICATION = 'dns.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'NAME': os.getenv("DJANGO_DATABASE_PATH", BASE_DIR / 'db.sqlite3'),
     }
 }
 

--- a/api/manage.py
+++ b/api/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Django's command-line utility for administrative tasks."""
 import os
 import sys

--- a/service/bin/gunicorn-start
+++ b/service/bin/gunicorn-start
@@ -9,4 +9,5 @@ export DJANGO_SECRET_KEY="$(tr -dc a-zA-Z0-9 < /dev/urandom | head -c 50)"
 export DJANGO_DEBUG="$(snapctl get django-debug)"
 export DJANGO_ALLOWED_HOSTS="$(snapctl get django-allowed-hosts)"
 export DJANGO_LOG_LEVEL="$(snapctl get django-log-level)"
+export DJANGO_LOG_LEVEL="$SNAP_COMMON/api/db.sqlite3"
 exec "$SNAP/usr/bin/gunicorn" --chdir "$SNAP_DATA/api" --bind unix:/tmp/gunicorn.sock dns.wsgi --capture-output --log-level=debug

--- a/service/bin/gunicorn-start
+++ b/service/bin/gunicorn-start
@@ -9,5 +9,5 @@ export DJANGO_SECRET_KEY="$(tr -dc a-zA-Z0-9 < /dev/urandom | head -c 50)"
 export DJANGO_DEBUG="$(snapctl get django-debug)"
 export DJANGO_ALLOWED_HOSTS="$(snapctl get django-allowed-hosts)"
 export DJANGO_LOG_LEVEL="$(snapctl get django-log-level)"
-export DJANGO_LOG_LEVEL="$SNAP_COMMON/api/db.sqlite3"
+export DJANGO_DATABASE_PATH="$SNAP_COMMON/api/db.sqlite3"
 exec "$SNAP/usr/bin/gunicorn" --chdir "$SNAP_DATA/api" --bind unix:/tmp/gunicorn.sock dns.wsgi --capture-output --log-level=debug

--- a/service/bin/manage
+++ b/service/bin/manage
@@ -4,5 +4,4 @@ export DJANGO_DEBUG="$(snapctl get django-debug)"
 export DJANGO_ALLOWED_HOSTS="$(snapctl get django-allowed-hosts)"
 export DJANGO_LOG_LEVEL="$(snapctl get django-log-level)"
 export DJANGO_DATABASE_PATH="$SNAP_COMMON/api/db.sqlite3"
-cd $SNAP_DATA/api
-exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- python3 manage.py $@
+exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- python3 $SNAP_DATA/api/manage.py $@

--- a/service/bin/manage
+++ b/service/bin/manage
@@ -3,6 +3,6 @@
 export DJANGO_DEBUG="$(snapctl get django-debug)"
 export DJANGO_ALLOWED_HOSTS="$(snapctl get django-allowed-hosts)"
 export DJANGO_LOG_LEVEL="$(snapctl get django-log-level)"
-export DJANGO_LOG_LEVEL="$SNAP_COMMON/api/db.sqlite3"
+export DJANGO_DATABASE_PATH="$SNAP_COMMON/api/db.sqlite3"
 cd $SNAP_DATA/api
 exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- python3 manage.py $@

--- a/service/bin/manage
+++ b/service/bin/manage
@@ -3,5 +3,6 @@
 export DJANGO_DEBUG="$(snapctl get django-debug)"
 export DJANGO_ALLOWED_HOSTS="$(snapctl get django-allowed-hosts)"
 export DJANGO_LOG_LEVEL="$(snapctl get django-log-level)"
+export DJANGO_LOG_LEVEL="$SNAP_COMMON/api/db.sqlite3"
 cd $SNAP_DATA/api
 exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- python3 manage.py $@

--- a/service/bin/named-reload
+++ b/service/bin/named-reload
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 set -xe
-exec "$SNAP/usr/sbin/rndc" -c "$SNAP_DATA/etc/bind/rndc.conf" reload
+exec "$SNAP/usr/sbin/rndc" -c "$SNAP_COMMON/bind/rndc.conf" reload

--- a/service/bin/named-start
+++ b/service/bin/named-start
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 set -xe
-exec "$SNAP/usr/sbin/named" -c "$SNAP_DATA/etc/bind/named.conf" -f
+exec "$SNAP/usr/sbin/named" -c "$SNAP_COMMON/bind/named.conf" -f

--- a/service/bin/named-stop
+++ b/service/bin/named-stop
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 set -xe
-exec "$SNAP/usr/sbin/rndc" -c "$SNAP_DATA/etc/bind/rndc.conf" stop
+exec "$SNAP/usr/sbin/rndc" -c "$SNAP_COMMON/bind/rndc.conf" stop

--- a/service/bin/prepare
+++ b/service/bin/prepare
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+# The goal of this script is to prepare
+
+set -xe
+
+# ----
+# NGINX
+# As nginx is only supplementary to the workload of the charm.
+# As such, its files are handled in SNAP_DATA
+
+# Copy nginx configuration
+cp -r --preserve=mode "$SNAP/nginx" "$SNAP_DATA/nginx"
+
+# Create some directories for nginx
+mkdir -p $SNAP_DATA/nginx/tmp/body
+mkdir -p $SNAP_DATA/nginx/tmp/nginx-proxy
+mkdir -p $SNAP_DATA/nginx/tmp/nginx-fastcgi
+mkdir -p $SNAP_DATA/nginx/tmp/nginx-uwsgi
+mkdir -p $SNAP_DATA/nginx/tmp/nginx-scgi
+
+# Edit nginx configuration
+sed -i \
+  -e "s|<SNAP_DATA>|${SNAP_DATA}|g" \
+  -e "s|<SNAP_COMMON>|${SNAP_COMMON}|g" \
+  "$SNAP_DATA/nginx/nginx.conf"
+
+# Change ownership of some snap directories to allow snap_daemon to read/write
+# https://snapcraft.io/docs/system-usernames
+chown -R 584788:root $SNAP_DATA/nginx
+
+# ----
+# BIND
+# Some parts of bind's files can be seen as part of the workload and renewed on refresh
+
+# Create some directories for bind
+mkdir -p "$SNAP_DATA/usr/share"
+mkdir -p "$SNAP_DATA/var/cache/bind"
+
+# Copy the config files to SNAP_DATA
+cp -rf --preserve=mode "$SNAP/usr/share/dns" "$SNAP_DATA/usr/share"
+
+# ----
+# API (django and gunicorn)
+# The only thing that should be kept between refreshes is the database
+
+# Create the static directory for django
+cp -r "$SNAP/api" "$SNAP_DATA/"
+chmod -R 755 $SNAP_DATA/api
+
+# Prepare the django app
+cd $SNAP_DATA/api
+export DJANGO_LOG_LEVEL="$SNAP_COMMON/api/db.sqlite3"
+export DJANGO_SECRET_KEY="testkey"
+python3 manage.py collectstatic --noinput
+
+# Change ownership of some snap directories to allow snap_daemon to read/write
+# https://snapcraft.io/docs/system-usernames
+chown -R 584788:root $SNAP_DATA/api

--- a/service/bin/prepare
+++ b/service/bin/prepare
@@ -49,10 +49,9 @@ cp -r "$SNAP/api" "$SNAP_DATA/"
 chmod -R 755 $SNAP_DATA/api
 
 # Prepare the django app
-cd $SNAP_DATA/api
 export DJANGO_DATABASE_PATH="$SNAP_COMMON/api/db.sqlite3"
 export DJANGO_SECRET_KEY="testkey"
-python3 manage.py collectstatic --noinput
+python3 $SNAP_DATA/api/manage.py collectstatic --noinput
 
 # Change ownership of some snap directories to allow snap_daemon to read/write
 # https://snapcraft.io/docs/system-usernames

--- a/service/bin/prepare
+++ b/service/bin/prepare
@@ -50,7 +50,7 @@ chmod -R 755 $SNAP_DATA/api
 
 # Prepare the django app
 cd $SNAP_DATA/api
-export DJANGO_LOG_LEVEL="$SNAP_COMMON/api/db.sqlite3"
+export DJANGO_DATABASE_PATH="$SNAP_COMMON/api/db.sqlite3"
 export DJANGO_SECRET_KEY="testkey"
 python3 manage.py collectstatic --noinput
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -26,7 +26,7 @@ cat "$SNAP_COMMON/bind/rndc.conf" | awk '/^# (Start|End|Use)/ {next} /^#/ {sub(/
 
 # Prepare the django database
 cd $SNAP_DATA/api
-export DJANGO_LOG_LEVEL="$SNAP_COMMON/api/db.sqlite3"
+export DJANGO_DATABASE_PATH="$SNAP_COMMON/api/db.sqlite3"
 export DJANGO_SECRET_KEY="testkey"
 python manage.py migrate --noinput
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -25,10 +25,9 @@ done
 cat "$SNAP_COMMON/bind/rndc.conf" | awk '/^# (Start|End|Use)/ {next} /^#/ {sub(/^# /, ""); print}' >> "$SNAP_COMMON/bind/named.conf"
 
 # Prepare the django database
-cd $SNAP_DATA/api
 export DJANGO_DATABASE_PATH="$SNAP_COMMON/api/db.sqlite3"
 export DJANGO_SECRET_KEY="testkey"
-python3 manage.py migrate --noinput
+python3 $SNAP_DATA/api/manage.py migrate --noinput
 
 # set default configuration values
 snapctl set django-debug='false'

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -2,58 +2,33 @@
 
 set -xe
 
-# Create some directories for bind
-mkdir -p "$SNAP_DATA/etc"
-mkdir -p "$SNAP_DATA/usr/share"
-mkdir -p "$SNAP_DATA/var/cache/bind"
+$SNAP/bin/prepare
 
-# Copy the config files to SNAP_DATA
-cp -rf --preserve=mode "$SNAP/etc/bind" "$SNAP_DATA/etc/bind"
-cp -rf --preserve=mode "$SNAP/usr/share/dns" "$SNAP_DATA/usr/share"
+# Create some directories
+mkdir -p $SNAP_COMMON/api
+
+# Copy the bind config files to SNAP_COMMON
+cp -rf --preserve=mode "$SNAP/etc/bind" "$SNAP_COMMON/bind"
 
 # Fix the config files to take the new location into account
 SNAP_CURRENT="/var/snap/$SNAP_NAME/current"
-for file in $SNAP_DATA/etc/bind/* ; do
+for file in $SNAP_COMMON/bind/* ; do
   sed -i "s#/var/#$SNAP_CURRENT/var/#g" "$file"
-  sed -i "s#/etc/#$SNAP_CURRENT/etc/#g" "$file"
   sed -i "s#/usr/share/#$SNAP_CURRENT/usr/share/#g" "$file"
+  sed -i "s#/etc/#$SNAP_COMMON/#g" "$file"
 done
 
 # Create rndc.conf
-"$SNAP/usr/sbin/rndc-confgen" > "$SNAP_DATA/etc/bind/rndc.conf"
+"$SNAP/usr/sbin/rndc-confgen" > "$SNAP_COMMON/bind/rndc.conf"
 
 # Amend named.conf with the generated rndc configuration
-cat "$SNAP_DATA/etc/bind/rndc.conf" | awk '/^# (Start|End|Use)/ {next} /^#/ {sub(/^# /, ""); print}' >> "$SNAP_DATA/etc/bind/named.conf"
+cat "$SNAP_COMMON/bind/rndc.conf" | awk '/^# (Start|End|Use)/ {next} /^#/ {sub(/^# /, ""); print}' >> "$SNAP_COMMON/bind/named.conf"
 
-# Copy nginx configuration
-cp -r --preserve=mode "$SNAP/nginx" "$SNAP_DATA/nginx"
-
-# Create some directories for nginx
-mkdir -p $SNAP_DATA/nginx/tmp/body
-mkdir -p $SNAP_DATA/nginx/tmp/nginx-proxy
-mkdir -p $SNAP_DATA/nginx/tmp/nginx-fastcgi
-mkdir -p $SNAP_DATA/nginx/tmp/nginx-uwsgi
-mkdir -p $SNAP_DATA/nginx/tmp/nginx-scgi
-
-# Edit nginx configuration
-sed -i \
-  -e "s|<SNAP_DATA>|${SNAP_DATA}|g" \
-  -e "s|<SNAP_COMMON>|${SNAP_COMMON}|g" \
-  "$SNAP_DATA/nginx/nginx.conf"
-
-# Create the static directory for django
-cp -r "$SNAP/api" "$SNAP_DATA/"
-chmod -R 755 $SNAP_DATA/api
-
-# Prepare the django app
+# Prepare the django database
 cd $SNAP_DATA/api
-DJANGO_SECRET_KEY="testkey" python3 manage.py collectstatic --noinput
-DJANGO_SECRET_KEY="testkey" python manage.py migrate --noinput
-
-# Change ownership of some snap directories to allow snap_daemon to read/write
-# https://snapcraft.io/docs/system-usernames
-chown -R 584788:root $SNAP_DATA/nginx
-chown -R 584788:root $SNAP_DATA/api
+export DJANGO_LOG_LEVEL="$SNAP_COMMON/api/db.sqlite3"
+export DJANGO_SECRET_KEY="testkey"
+python manage.py migrate --noinput
 
 # set default configuration values
 snapctl set django-debug='false'

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -28,7 +28,7 @@ cat "$SNAP_COMMON/bind/rndc.conf" | awk '/^# (Start|End|Use)/ {next} /^#/ {sub(/
 cd $SNAP_DATA/api
 export DJANGO_DATABASE_PATH="$SNAP_COMMON/api/db.sqlite3"
 export DJANGO_SECRET_KEY="testkey"
-python manage.py migrate --noinput
+python3 manage.py migrate --noinput
 
 # set default configuration values
 snapctl set django-debug='false'

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -5,7 +5,6 @@ set -xe
 $SNAP/bin/prepare
 
 # Prepare the django database
-cd $SNAP_DATA/api
 export DJANGO_DATABASE_PATH="$SNAP_COMMON/api/db.sqlite3"
 export DJANGO_SECRET_KEY="testkey"
-python3 manage.py migrate --noinput
+python3 $SNAP_DATA/api/manage.py migrate --noinput

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -xe
+
+$SNAP/bin/prepare
+
+# Prepare the django database
+cd $SNAP_DATA/api
+export DJANGO_DATABASE_PATH="$SNAP_COMMON/api/db.sqlite3"
+export DJANGO_SECRET_KEY="testkey"
+python manage.py migrate --noinput

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -8,4 +8,4 @@ $SNAP/bin/prepare
 cd $SNAP_DATA/api
 export DJANGO_DATABASE_PATH="$SNAP_COMMON/api/db.sqlite3"
 export DJANGO_SECRET_KEY="testkey"
-python manage.py migrate --noinput
+python3 manage.py migrate --noinput


### PR DESCRIPTION
This extracts some logic out of the `install` hook to a `prepare` script that is also used by the new `post-refresh` hook.  